### PR TITLE
Change labeling of fig. 3.1

### DIFF
--- a/script/chapter3.tex
+++ b/script/chapter3.tex
@@ -99,7 +99,7 @@ We can think of $E<0$ solution as particle flying backwards in time or $E > 0$ a
 \begin{figure}[ht]
    \centering
    \includegraphics[width=0.8\linewidth]{fs-interpretation/fs-interpretation.eps}
-   \caption{scattering process; horizontal time-axis; in the second diagram a electron positron pair is produced}%
+   \caption{scattering process; vertical time-axis; in the second diagram a electron positron pair is produced}%
    \label{fig:}
 \end{figure}
 


### PR DESCRIPTION
For the positron to be a particle going backwards in time, the time-axis needs to be vertical. Thanks for publishing your notes! :)